### PR TITLE
fixed https

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -15,6 +15,7 @@ class nextcloud::database (
       mysqld      => {
         'log-error' => '/var/log/mysql/mariadb.log',
         'pid-file'  => '/var/run/mysqld/mysqld.pid',
+        'plugin-load-add'  => 'auth_socket.so',
       },
       mysqld_safe => {
         'log-error' => '/var/log/mysql/mariadb.log',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class nextcloud (
   Integer $http_port                                  = 80,
   Integer $https_port                                 = 443,
   Boolean $ssl                                        = true,
+  Boolean $server_purge                               = false,
   Variant[Undef, Stdlib::Absolutepath] $ssl_key_file  = undef,
   Variant[Undef, Stdlib::Absolutepath] $ssl_cert_file = undef,
   String $php_version                                 = '7.0',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,12 +5,12 @@ class nextcloud::install {
     owner  => 'www-data',
     group  => 'www-data',
   }
-  -> archive { '/var/www/html/nextcloud-13.0.4.tar.bz2':
+  -> archive { '/var/www/html/nextcloud-13.0.7.tar.bz2':
     ensure       => present,
-    path         => '/tmp/nextcloud-13.0.4.tar.bz2',
+    path         => '/tmp/nextcloud-13.0.7.tar.bz2',
     extract      => true,
     extract_path => '/var/www/html',
-    source       => 'https://download.nextcloud.com/server/releases/nextcloud-13.0.6.tar.bz2',
+    source       => 'https://download.nextcloud.com/server/releases/nextcloud-13.0.7.tar.bz2',
     creates      => '/var/www/html/nextcloud/index.php',
     cleanup      => true,
     user         => 'www-data',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,12 +5,12 @@ class nextcloud::install {
     owner  => 'www-data',
     group  => 'www-data',
   }
-  -> archive { '/var/www/html/nextcloud-13.0.2.tar.bz2':
+  -> archive { '/var/www/html/nextcloud-13.0.4.tar.bz2':
     ensure       => present,
-    path         => '/tmp/nextcloud-13.0.2.tar.bz2',
+    path         => '/tmp/nextcloud-13.0.4.tar.bz2',
     extract      => true,
     extract_path => '/var/www/html',
-    source       => 'https://download.nextcloud.com/server/releases/nextcloud-13.0.2.tar.bz2',
+    source       => 'https://download.nextcloud.com/server/releases/nextcloud-13.0.6.tar.bz2',
     creates      => '/var/www/html/nextcloud/index.php',
     cleanup      => true,
     user         => 'www-data',


### PR DESCRIPTION
I added some config options, fixed https by basically copying the entire server section in both sections for https true/false. I also changed a flag for fastcgi so it will automatically do https if this is enabled.

This works for me for non-https. I am still figuring out how to get it automated with certbot, so I haven't yet tested the https part of it. Even if that isn't working flawlessly, fixing it without breaking non-https should be a lot easier since both sections are completely independent now.

I now see that I have both 13.0.4 and 13.0.6 as versions mixed in my pull request. You may want to fix that.
One of my next steps will be to update such that the version can be in init.pp and based on that the URL for download will be generated. I will probably even try to figure out if I can script an upgrade so that an existing config will run the nextcloud upgrade script to upgrade to the preferred version.